### PR TITLE
Add marketdesigners/da24-mcp-server to Commerce & Retail

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Only projects meeting all of the following criteria are listed.
 
 > MCP servers related to Korean e-commerce, open markets, and shopping services.
 
+**[marketdesigners/da24-mcp-server](https://github.com/marketdesigners/da24-mcp-server)** – 짐 목록으로 소형이사 예상 견적을 계산하고 다이사 플랫폼에 이사 문의를 접수할 수 있는 MCP 서버로, Claude, ChatGPT, Grok, Gemini CLI 등과 연동 가능합니다.
+
 **[daiso-mcp](https://github.com/hmmhmmhm/daiso-mcp)** – 주변 다이소 매장을 검색하고, 원하는 상품의 재고 여부 및 가격을 조회하는 MCP 서버. ChatGPT, Claude, Grok 등 AI 앱과 연동 가능.
 
 **[edward-kim-dev/kr-pc-deals-mcp](https://github.com/edward-kim-dev/kr-pc-deals-mcp)** – 다나와·컴퓨존 PC 부품 최저가 검색, 가격 비교, 가격 이력, 빌드 견적, CPU-메인보드-RAM 호환성 체크를 제공하는 MCP 서버입니다.


### PR DESCRIPTION
## 추가 항목

**[marketdesigners/da24-mcp-server](https://github.com/marketdesigners/da24-mcp-server)** – 짐 목록으로 소형이사 예상 견적을 계산하고 다이사 플랫폼에 이사 문의를 접수할 수 있는 MCP 서버로, Claude, ChatGPT, Grok, Gemini CLI 등과 연동 가능합니다.

## 카테고리

🛒 Commerce & Retail

## 체크리스트

- [x] 공개적으로 접근 가능한 저장소
- [x] 한국 생태계 명확히 지원 (한국 이사 견적/접수 서비스)
- [x] MCP 명세 구현
- [x] 기본 문서(README) 포함
- [x] 1개 PR에 1개 프로젝트
- [x] 알파벳 순서 유지 (da24 → daiso 앞)
- [x] CONTRIBUTING.md 형식 준수