### PR TITLE
feat: add koreanpulse - 행동주의/외국인 투자자 분류 영어 MCP 서버

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Only projects meeting all of the following criteria are listed.
 
 **[aesthetic-legalism5470/korean-dart-mcp](https://github.com/aesthetic-legalism5470/korean-dart-mcp)** – OpenDART API를 기반으로 공시·재무·지분·XBRL 데이터를 조회하고 첨부 문서를 처리하는 MCP 서버입니다.
 
-**[whdrnr2583-cmd/koreanpulse](https://github.com/whdrnr2583-cmd/koreanpulse)** – DART 공시·5%룰 행동주의 투자자(KCGI, 얼라인파트너스, ValueAct, Elliott) 분류·외국인 보유자(BlackRock, Vanguard, Norges Bank) 변동을 영어로 제공하는 글로벌 투자자 대상 MCP 서버입니다.
+**[KoreanPulse](https://github.com/whdrnr2583-cmd/koreanpulse)** – 한국 DART 기업공시를 영어로 번역해 제공하는 호스티드 원격 MCP 서버(mcp.koreanpulse.dev/mcp)로, 다중 기업 배치 스캔·정정공시 연결·DART 접수번호 출처 추적을 지원하며 5개 도구는 DART API 키 없이 무료이고 행동주의·외국인 지분 분류 2개 도구는 라이선스 전용입니다.
 
 **[koreainvestment-mcp](https://github.com/koreainvestment/koreainvestment-mcp)** – 한국투자증권 API를 자연어로 검색해 필요한 금융 API를 찾을 수 있는 MCP 서버입니다.
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Only projects meeting all of the following criteria are listed.
 
 **[aesthetic-legalism5470/korean-dart-mcp](https://github.com/aesthetic-legalism5470/korean-dart-mcp)** – OpenDART API를 기반으로 공시·재무·지분·XBRL 데이터를 조회하고 첨부 문서를 처리하는 MCP 서버입니다.
 
+**[whdrnr2583-cmd/koreanpulse](https://github.com/whdrnr2583-cmd/koreanpulse)** – DART 공시·5%룰 행동주의 투자자(KCGI, 얼라인파트너스, ValueAct, Elliott) 분류·외국인 보유자(BlackRock, Vanguard, Norges Bank) 변동을 영어로 제공하는 글로벌 투자자 대상 MCP 서버입니다.
+
 **[koreainvestment-mcp](https://github.com/koreainvestment/koreainvestment-mcp)** – 한국투자증권 API를 자연어로 검색해 필요한 금융 API를 찾을 수 있는 MCP 서버입니다.
 
 **[pykrx-mcp](https://github.com/sharebook-kr/pykrx-mcp)** – pykrx 라이브러리 기반으로 KOSPI·KOSDAQ·KONEX 주가, 재무제표, 투자자별 수급 및 공매도 데이터를 제공하는 MCP 서버입니다.


### PR DESCRIPTION
Add [koreanpulse](https://github.com/whdrnr2583-cmd/koreanpulse) to the Finance & Tax section.

**프로젝트 설명**: DART 공시·5%룰 행동주의 투자자 분류(KCGI, 얼라인파트너스, ValueAct, Elliott)·외국인 보유자 변동(BlackRock, Vanguard, Norges Bank)을 영어로 제공하는 글로벌 투자자 대상 MCP 서버.

**다른 항목과의 차별점**: 기존 등재 서버들이 원시 DART 데이터를 반환하는 것과 달리, koreanpulse는 5%룰 공시 주체를 행동주의/외국인 투자자 카테고리로 분류하는 레이어를 제공합니다. 외국인 투자자가 직접 Claude/ChatGPT에 연결하여 영어로 조회 가능.

**적격 기준 확인**:
- MCP 스펙 구현: FastMCP 기반, stdio + streamable-HTTP 지원
- 한국 시장/생태계 대상: DART/KRX 특화, 한국어 공시 영어 변환
- 공개 접근 가능: https://mcp.koreanpulse.dev/mcp (hosted) + pip install koreanpulse
- 기본 문서 포함: README, ARCHITECTURE.md, CLAUDE_DESKTOP.md
- 활성 프로젝트: v0.1.11, 2026-05-06 최초 배포

- Language: Python (FastMCP)
- License: AGPL-3.0
- PyPI: koreanpulse v0.1.11